### PR TITLE
Remove required username/password from /auth/basic

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -46,9 +46,6 @@ paths:
               properties:
                 expires_in:
                   type: integer
-              required:
-                - username
-                - password
               example:
                 expires_in: 300
         required: false


### PR DESCRIPTION
This endpoint was incorrectly requirng username / password in the requestBody.