### PR TITLE
Vercel integration

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -1,0 +1,8 @@
+import sys
+sys.path.append('../')
+sys.path.append('../src')
+
+# This is required for Vercel
+from a2wsgi import ASGIMiddleware
+from run import app as asgi_app
+app = ASGIMiddleware(asgi_app)

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+    "rewrites": [
+        { "source": "/(.*)", "destination": "/api/app" }
+    ]
+}


### PR DESCRIPTION
This should now work perfectly in Vercel.

Two important notes:
* yes, we do need the ASGIMiddleware
* yes, we do need the rewrites

If we don't add the rewrites, Vercel handles all of the routing incorrectly. You don't need to add the "functions" bit though, as Vercel will automatically recognize .py files in the api directory.

It is crucial that there is an entrypoint available in the api directory, though. It is currently non-negotiable -- you can't configure it any other way, and Vercel won't recognize the entry point anywhere else.

The ASGIMiddleware is the result of a _lot_ of trial and error. Here's some important findings, for later notes (I might genuinely ping the Vercel folks about this):
* If you try to create an app using `connexion`, it makes an ASGI app
* if you give that to the Vercel server, it gets very confused with the encode/decode. The runtime completely garbles it. It ended up making a bunch of garbles headers, with, for example,  `b'application/json'` in the `Content-Type` instead of `application/json`. It also wrecked 307s as well
* if you take your ASGI app and wrap it using ASGIMiddleware (from the folks over at `a2wsgi`), you get a WSGI app back -- Vercel appears to be able to handle that very smoothly.

Of course, using WSGI instead of ASGI will come with some performance degradation, but otherwise it works as expected.